### PR TITLE
Change gunicorn.conf.py loglevel to debug

### DIFF
--- a/api/gunicorn.conf.py
+++ b/api/gunicorn.conf.py
@@ -2,5 +2,6 @@ import os
 bind = '[::]:8080'
 #accesslog = 'gunicorn.log'
 #errorlog = 'gunicorn.error.log'
+loglevel='debug'
 workers = int(os.getenv('GUNICORN_WORKERS'))
 threads = int(os.getenv('GUNICORN_THREADS'))


### PR DESCRIPTION
Just changes the loglevel to allow debuggin on Render.com deployment.