### PR TITLE
Added JWT authentication support on routes and specific tasks

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,10 +1,11 @@
 import sys
 from server import app, api
-from resources.web import NewTask, ViewTask, Ping, ProtectedByJwt, GenerateTokenForUser
+from resources.web import NewTask, ViewTask, Ping, ProtectedByJwt, GenerateTokenForUser, ViewTaskList
 
-#   Unprotected routes
+#   Unprotected routes (except protected tasks)
 api.add_resource(NewTask, '/task/new')
 api.add_resource(ViewTask, '/task/<string:task_id>/view')
+api.add_resource(ViewTaskList, '/tasks')
 api.add_resource(Ping, '/ping')
 
 #   Protected routes

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -3,12 +3,12 @@ from sqlalchemy.orm import sessionmaker, scoped_session
 from celery import Celery
 import time as time
 import os
+from resources.auth import authorized_task
 
 database_url=os.getenv('DATABASE_URL').replace('postgres', 'postgresql', 1)
 amqp_url=os.getenv('AMQP_URL')
 app = Celery('tasks', backend='db+'+database_url, broker=amqp_url)
 app.conf.task_default_queue = 'tasks'
-#app.config_from_object('celeryconfig')
 
 @app.task
 def add(x: int, y: int):
@@ -16,4 +16,9 @@ def add(x: int, y: int):
 
 @app.task
 def mov3d(dt: float, r0: list, v0: list, mass: float, radius: float, drag: bool):
+    return None
+
+@authorized_task
+@app.task
+def myProtectedTask(x: int, y: int):
     return None

--- a/handler/tasks.py
+++ b/handler/tasks.py
@@ -27,3 +27,7 @@ def mov3d(dt: float, r0: list, v0: list, mass: float, radius: float, drag: bool)
 
     result = sim.result
     return result
+
+@app.task
+def myProtectedTask(x: int, y: int)
+    return x+y


### PR DESCRIPTION
- Added /tasks route that list all tasks, their args and if they need authorization.

- Added JWT authorization for tasks: just add the @authorized_task on top of @app.tasks in a task on api/tasks.py to use authorization in a task; the JWT must contain {allowed_tasks: {yourTaskName: True}} to allow the usage of task; if False, it will return an unauthorization error on task POST. 

- Added function verify_credentials(user, pass) in api/resources/auth.py to validate the user and password passed args on /token endpoint: you can implement any algorithm that you want to validate the credentials, and it should return True or False. 

- Added function get_user_permissions(user, password) to retrieve the dict with {allowed_tasks: ...}; you can implement any algorithm that you want to retrieve this data from a database.